### PR TITLE
Upgrade Sentry SDK to 2.0+

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Use it to send your errors and exceptions to your Sentry account.
    Alternatively, you can pass in a pre-configured Sentry client when you instantiate the handler:
    
    ```
-   $sentry = new Raven_Client("https://abcdefghijklmnopqrstuvwxyz123456@sentry.io/123456");
-   $handler = new SentryHandler($sentry);
+   $client = Sentry\ClientBuilder::create(["dsn" => "..."]);
+   $handler = new SentryHandler($client);
    
    $slashtrace->addHandler($handler);
    ```

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">= 7.1",
         "slashtrace/slashtrace": "^1.0",
-        "sentry/sentry": "^1.9"
+        "sentry/sdk": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": ">= 5.6",
+        "php": ">= 7.1",
         "slashtrace/slashtrace": "^1.0",
         "sentry/sentry": "^1.9"
     },


### PR DESCRIPTION
- Use the [new Sentry SDK](https://github.com/getsentry/sentry-php/blob/master/UPGRADE-2.0.md).
- Make PHP 7.1+ a requirement, in accordance with the currently supported [PHP versions](https://php.net/supported-versions.php).